### PR TITLE
Add alias to list all aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run `./install.sh` to sync the repository into `~/.local/share/dotfiles` and sou
 
 ## Aliases
 - `git-prune-branches`: fetch all remote branches, check out `main`, and delete all other local branches.
+- `aliases`: list all defined aliases with descriptions.
 
 ## Syncing scripts
 - `./sync.sh`: mirror repository files into `~/.local/share/dotfiles` using `rsync`.

--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -1,3 +1,27 @@
 #!/bin/sh
 # Git related aliases
+
+alias_git_prune_branches_desc='fetch all remote branches, check out main, and delete all other local branches'
+alias_aliases_desc='list all defined aliases with descriptions'
+
+_aliases() {
+  alias -p | while IFS= read -r line; do
+    name=$(printf '%s' "$line" | sed -n "s/^alias \([^=]*\)=.*/\1/p")
+    case "$name" in
+      git-prune-branches)
+        desc=$alias_git_prune_branches_desc
+        ;;
+      aliases)
+        desc=$alias_aliases_desc
+        ;;
+      *)
+        desc=''
+        ;;
+    esac
+    printf '%s # %s\n' "$line" "$desc"
+  done
+}
+
 alias git-prune-branches='git fetch --all && git checkout main && git branch | grep -v "main" | xargs git branch -D'
+alias aliases='_aliases'
+


### PR DESCRIPTION
## Summary
- add `aliases` shortcut to display all configured aliases with descriptions
- document the enhanced alias listing

## Testing
- `shellcheck aliases/git.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b414f69d1883238ba29d6d3380e7ac