### PR TITLE
Improve git alias script readability

### DIFF
--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Git related aliases
 
 alias_git_prune_branches_desc='fetch all remote branches, check out main, and delete all other local branches'
@@ -6,6 +6,7 @@ alias_aliases_desc='list all defined aliases with descriptions'
 
 _aliases() {
   alias -p | while IFS= read -r line; do
+    local name desc
     name=$(printf '%s' "$line" | sed -n "s/^alias \([^=]*\)=.*/\1/p")
     case "$name" in
       git-prune-branches)
@@ -24,4 +25,3 @@ _aliases() {
 
 alias git-prune-branches='git fetch --all && git checkout main && git branch | grep -v "main" | xargs git branch -D'
 alias aliases='_aliases'
-


### PR DESCRIPTION
## Summary
- use `/usr/bin/env bash` shebang for git alias script
- add local variables in alias helper for clarity

## Testing
- `shellcheck install.sh sync.sh`
- `shellcheck aliases/git.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b418aabdf08323a5bd2d27dbc87544