### PR TITLE
Load aliases after install and sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 This repository contains a bash/shell project structure to manage personal dotfiles.
 
 ## Installation
-Run `./install.sh` to sync the repository into `~/.local/share/dotfiles` and source the aliases in your `~/.bashrc`. Restart your shell to use the aliases.
+Run `./install.sh` to sync the repository into `~/.local/share/dotfiles` and source the aliases in your `~/.bashrc` or `~/.zshrc`. The aliases are also loaded for your current shell session.
 
 ## Aliases
 - `git-prune-branches`: fetch all remote branches, check out `main`, and delete all other local branches.
 - `aliases`: list all defined aliases with descriptions.
 
 ## Syncing scripts
-- `./sync.sh`: mirror repository files into `~/.local/share/dotfiles` using `rsync`.
+- `./sync.sh`: mirror repository files into `~/.local/share/dotfiles` using `rsync` and reload the alias definitions.

--- a/install.sh
+++ b/install.sh
@@ -7,11 +7,20 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Mirror repository files to the local share directory
 "$REPO_DIR/sync.sh"
 
-PROFILE="$HOME/.bashrc"
+PROFILES=("$HOME/.bashrc" "$HOME/.zshrc")
+ALIASES_FILE="$HOME/.local/share/dotfiles/aliases/git.sh"
 # shellcheck disable=SC2016
 ALIASES_SNIPPET='[ -f "$HOME/.local/share/dotfiles/aliases/git.sh" ] && source "$HOME/.local/share/dotfiles/aliases/git.sh"'
 
-touch "$PROFILE"
-if ! grep -Fqx "$ALIASES_SNIPPET" "$PROFILE"; then
-  echo "$ALIASES_SNIPPET" >> "$PROFILE"
+for PROFILE in "${PROFILES[@]}"; do
+  touch "$PROFILE"
+  if ! grep -Fqx "$ALIASES_SNIPPET" "$PROFILE"; then
+    echo "$ALIASES_SNIPPET" >> "$PROFILE"
+  fi
+done
+
+# Load aliases immediately for local use
+if [ -f "$ALIASES_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ALIASES_FILE"
 fi

--- a/sync.sh
+++ b/sync.sh
@@ -7,3 +7,9 @@ DEST="${HOME}/.local/share/dotfiles"
 
 mkdir -p "$DEST"
 rsync -av --delete --exclude '.git/' "$REPO_DIR"/ "$DEST"/
+
+ALIASES_FILE="$DEST/aliases/git.sh"
+if [ -f "$ALIASES_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ALIASES_FILE"
+fi


### PR DESCRIPTION
## Summary
- Load alias definitions immediately after syncing files in `install.sh`
- Source aliases in `sync.sh` so changes are usable right away
- Document that install and sync reload aliases for the current shell session
- Configure install to update both `.bashrc` and `.zshrc`

## Testing
- `bash -n install.sh`
- `bash -n sync.sh`
- `source install.sh`
- `alias git-prune-branches`
- `cat ~/.zshrc`


------
https://chatgpt.com/codex/tasks/task_e_68b4189cd96c8323ba677f5542c8914e