### PR TITLE
fix: ensure aliases work in zsh

### DIFF
--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -5,8 +5,8 @@ alias_git_prune_branches_desc='fetch all remote branches, check out main, and de
 alias_aliases_desc='list all defined aliases with descriptions'
 
 _aliases() {
-  alias -p | while IFS= read -r line; do
-    local name desc
+  alias | while IFS= read -r line; do
+    local name="" desc=""
     name=$(printf '%s' "$line" | sed -n "s/^alias \([^=]*\)=.*/\1/p")
     case "$name" in
       git-prune-branches)


### PR DESCRIPTION
## Summary
- make alias-listing helper shell-agnostic by removing bash-only `alias -p`
- initialize variables to avoid extraneous output

## Testing
- `find . -name '*.sh' -print0 | xargs -0 -n1 bash -n`
- `zsh -ic 'source aliases/git.sh; aliases'`


------
https://chatgpt.com/codex/tasks/task_e_68b41b199fd483239ce6ee02b0c84a13