### PR TITLE
Ensure aliases load in zsh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ ALIASES_SNIPPET='[ -f "$HOME/.local/share/dotfiles/aliases/git.sh" ] && source "
 for PROFILE in "${PROFILES[@]}"; do
   touch "$PROFILE"
   if ! grep -Fqx "$ALIASES_SNIPPET" "$PROFILE"; then
-    echo "$ALIASES_SNIPPET" >> "$PROFILE"
+    printf '\n%s\n' "$ALIASES_SNIPPET" >> "$PROFILE"
   fi
 done
 


### PR DESCRIPTION
## Summary
- append alias sourcing snippet with newline so .bashrc and .zshrc load aliases correctly

## Testing
- `find . -name '*.sh' -print0 | xargs -0 -n1 bash -n`
- `zsh -ic 'alias git-prune-branches'`


------
https://chatgpt.com/codex/tasks/task_e_68b41fcc9bac8323a19c4e5a2e9888c6