### PR TITLE
Make sync script zsh-friendly

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+# Enable strict mode for both Bash and Zsh
+set -e
+set -u
+set -o pipefail
 
 # Synchronize repository scripts to local environment
-REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Determine the directory containing this script for Bash and Zsh
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+  SCRIPT_PATH="${BASH_SOURCE[0]}"
+else
+  # shellcheck disable=SC2296  # zsh-specific parameter expansion
+  SCRIPT_PATH="${(%):-%x}"
+fi
+REPO_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
 DEST="${HOME}/.local/share/dotfiles"
 
 mkdir -p "$DEST"


### PR DESCRIPTION
## Summary
- Ensure `sync.sh` runs with strict mode in both Bash and Zsh
- Detect script path portably so sourcing works in Zsh

## Testing
- `shellcheck sync.sh`
- `zsh -c 'source sync.sh'`


------
https://chatgpt.com/codex/tasks/task_e_68b421f3a40c8323800aeed2890b1f0a