### PR TITLE
Simplify alias command color scheme and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run `./install.sh` to sync the repository into `~/.local/share/dotfiles` and sou
 
 ## Aliases
 - `git-prune-branches`: fetch all remote branches, check out `main`, and delete all other local branches.
-- `aliases`: list all defined aliases with descriptions in a colorized table.
+- `aliases`: list all defined aliases with descriptions in a simplified colorized list.
 
 ## Syncing scripts
 - `./sync.sh`: mirror repository files into `~/.local/share/dotfiles` using `rsync` and reload the alias definitions.

--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -11,14 +11,12 @@ _git_prune_branches() {
 }
 
 _aliases() {
-  local bold reset header_color alias_color desc_color bullet_color
+  local bold reset header_color alias_color
   local line name desc
   bold=$(printf '\033[1m')
   reset=$(printf '\033[0m')
   header_color=$(printf '\033[36m')
   alias_color=$(printf '\033[32m')
-  desc_color=$(printf '\033[33m')
-  bullet_color=$(printf '\033[35m')
 
   printf '%b%s%b\n' "$bold$header_color" "✨ Alias disponibles" "$reset"
   alias | while IFS= read -r line; do
@@ -35,13 +33,11 @@ _aliases() {
         ;;
     esac
     if [ -n "$desc" ]; then
-      printf '  %b•%b %b%s%b %b→ %s%b\n' \
-        "$bullet_color" "$reset" \
+      printf '  • %b%s%b\n      %s\n' \
         "$alias_color" "$name" "$reset" \
-        "$desc_color" "$desc" "$reset"
+        "$desc"
     else
-      printf '  %b•%b %b%s%b\n' \
-        "$bullet_color" "$reset" \
+      printf '  • %b%s%b\n' \
         "$alias_color" "$name" "$reset"
     fi
   done


### PR DESCRIPTION
## Summary
- Streamline `aliases` command output by reducing color usage and placing descriptions beneath each alias
- Update documentation to reflect simplified alias listing

## Testing
- `bash -n aliases/git.sh`
- `bash -lc 'source aliases/git.sh; _aliases'`

------
https://chatgpt.com/codex/tasks/task_e_68b4252269688323af6956801e81197e