### PR TITLE
Skip checkout when already on main in branch pruning alias

### DIFF
--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -6,8 +6,10 @@ alias_aliases_desc='List all defined aliases with descriptions'
 
 _git_prune_branches() {
   git fetch --all
-  git checkout main
-  git branch | grep -v "main" | xargs git branch -D
+  if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
+    git checkout main
+  fi
+  git branch --list | grep -vE '^\*?\s*main$' | xargs -r git branch -D
 }
 
 _aliases() {


### PR DESCRIPTION
## Summary
- avoid unnecessary checkout in `git-prune-branches`
- robust deletion of non-main branches

## Testing
- `bash -n aliases/git.sh`
- `_git_prune_branches` on a temporary repo

------
https://chatgpt.com/codex/tasks/task_e_68b425bf1a5c8323b9cfc06afe4ec7eb