### PR TITLE
Use global zsh emulation for profile configuration

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -4,7 +4,9 @@
 # Synchronize repository scripts to local environment or perform installation
 
 if [ -n "${ZSH_VERSION:-}" ]; then
-  emulate -L sh
+  # Use global emulation to avoid scoping functions to the file when sourced under zsh.
+  # This ensures helper functions like configure_profiles persist in the caller's environment.
+  emulate sh
   set -e
   set -u
   set -o pipefail


### PR DESCRIPTION
## Summary
- avoid local-only scope when running under zsh by using global emulation
- document why global emulation is needed so configure_profiles stays available

## Testing
- `bash -n sync.sh`
- `shellcheck sync.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b43826714c83239945bf8d66795d37