### PR TITLE
Ensure progress bar clears previous output

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -6,7 +6,8 @@
 print_over() {
   local fmt=$1
   shift
-  printf "$fmt\033[K" "$@"
+  # shellcheck disable=SC2059
+  printf "\r$fmt\033[K" "$@"
 }
 
 # Display a simple progress bar.


### PR DESCRIPTION
## Summary
- Reset cursor before printing progress updates so old bars disappear
- Silence ShellCheck's dynamic format warning for `print_over`

## Testing
- `shellcheck helpers.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b43fadbd7c8323a9eba1a74f230284