### PR TITLE
Suppress fetch progress in git-prune-branches

### DIFF
--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -5,7 +5,7 @@ alias_git_prune_branches_desc='Fetch all remote branches, check out main, and de
 alias_aliases_desc='List all defined aliases with descriptions'
 
 _git_prune_branches() {
-  git fetch --all --prune
+  git fetch --all --prune --quiet
   if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
     git checkout main
   fi


### PR DESCRIPTION
## Summary
- suppress progress output from `git fetch` in `git-prune-branches` to prevent stray characters in messages

## Testing
- `bash -n aliases/git.sh`
- `shellcheck aliases/git.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b44d983bd08323876216c2cabe2d61