### PR TITLE
Fix literal output in print_over

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -18,8 +18,12 @@ print_over() {
     printf '\r'
   fi
   printf '\033[J'
-  # shellcheck disable=SC2059
-  printf "$fmt" "$@"
+  if [[ $# -gt 0 ]]; then
+    # shellcheck disable=SC2059
+    printf "$fmt" "$@"
+  else
+    printf '%b' "$fmt"
+  fi
 }
 
 # Display a simple progress bar.


### PR DESCRIPTION
## Summary
- handle literal strings correctly in `print_over`

## Testing
- `shellcheck helpers.sh`
- `bash -n helpers.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b44fceb1348323b7988099205635a1