### PR TITLE
feat: add package installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a bash/shell project structure to manage personal dotfiles.
 
 ## Installation
-Run `./install.sh` or `./sync.sh --install` to configure Git hooks, sync the repository into `~/.local/share/dotfiles`, and source the aliases in your `~/.bashrc` or `~/.zshrc`. The aliases and helper functions are also loaded for your current shell session, and subsequent `./sync.sh` runs keep your profiles up to date.
+Run `./install.sh` (which also installs missing dependencies) or `./sync.sh --install` to configure Git hooks, sync the repository into `~/.local/share/dotfiles`, and source the aliases in your `~/.bashrc` or `~/.zshrc`. The aliases and helper functions are also loaded for your current shell session, and subsequent `./sync.sh` runs keep your profiles up to date.
 
 ## Aliases
 - `git-prune-branches`: fetch all remote branches, check out `main`, and delete all other local and remote branches.

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REQUIRED_CMDS=(nvim)
+# Map commands to package names when they differ
+declare -A PKG_MAP=([nvim]=neovim)
+
+missing=()
+for cmd in "${REQUIRED_CMDS[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    pkg="${PKG_MAP[$cmd]:-$cmd}"
+    missing+=("$pkg")
+  fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+  exit 0
+fi
+
+SUDO=""
+if command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+fi
+
+if command -v apt >/dev/null 2>&1; then
+  $SUDO apt-get update
+  $SUDO apt-get install -y "${missing[@]}"
+elif command -v brew >/dev/null 2>&1; then
+  $SUDO brew install "${missing[@]}"
+elif command -v dnf >/dev/null 2>&1; then
+  $SUDO dnf install -y "${missing[@]}"
+elif command -v pacman >/dev/null 2>&1; then
+  $SUDO pacman -Syu --noconfirm "${missing[@]}"
+else
+  echo "No supported package manager found. Please install: ${missing[*]}" >&2
+  exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"$REPO_DIR/install-packages.sh"
 "$REPO_DIR/sync.sh" --install "$@"


### PR DESCRIPTION
## Summary
- add `install-packages.sh` to install missing dependencies using apt, brew, etc.
- run package installation before syncing files in `install.sh`
- document dependency installation in README

## Testing
- `shellcheck install-packages.sh install.sh sync.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6938f4d308323a2f94573df7894f9