### PR TITLE
Exclude unnecessary directories from sync

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -39,7 +39,12 @@ load_env() {
 
 sync_repo() {
   mkdir -p "$DEST"
-  rsync -av --delete --exclude '.git/' "$REPO_DIR"/ "$DEST"/
+  rsync -av --delete \
+    --exclude '.git/' \
+    --exclude '.github/' \
+    --exclude 'hooks/' \
+    --exclude '.idea/' \
+    "$REPO_DIR"/ "$DEST"/
   load_env
   configure_profiles
 }


### PR DESCRIPTION
## Summary
- avoid syncing repository metadata directories (.git, .github)
- skip syncing hooks and IDE metadata

## Testing
- `bash -n sync.sh`
- `shellcheck sync.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6955b4840832382b599438a585545