### PR TITLE
Add verbose output to installation scripts

### DIFF
--- a/install-packages.sh
+++ b/install-packages.sh
@@ -5,6 +5,7 @@ REQUIRED_CMDS=(nvim)
 # Map commands to package names when they differ
 declare -A PKG_MAP=([nvim]=neovim)
 
+echo "Checking required commands: ${REQUIRED_CMDS[*]}"
 missing=()
 for cmd in "${REQUIRED_CMDS[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -14,24 +15,31 @@ for cmd in "${REQUIRED_CMDS[@]}"; do
 done
 
 if [ ${#missing[@]} -eq 0 ]; then
+  echo "All required packages are installed."
   exit 0
 fi
 
+echo "Missing packages: ${missing[*]}"
 SUDO=""
 if command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
 if command -v apt >/dev/null 2>&1; then
+  echo "Installing with apt-get: ${missing[*]}"
   $SUDO apt-get update
   $SUDO apt-get install -y "${missing[@]}"
 elif command -v brew >/dev/null 2>&1; then
+  echo "Installing with brew: ${missing[*]}"
   $SUDO brew install "${missing[@]}"
 elif command -v dnf >/dev/null 2>&1; then
+  echo "Installing with dnf: ${missing[*]}"
   $SUDO dnf install -y "${missing[@]}"
 elif command -v pacman >/dev/null 2>&1; then
+  echo "Installing with pacman: ${missing[*]}"
   $SUDO pacman -Syu --noconfirm "${missing[@]}"
 else
   echo "No supported package manager found. Please install: ${missing[*]}" >&2
   exit 1
 fi
+echo "Package installation complete."

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "Installing required packages..."
 "$REPO_DIR/install-packages.sh"
+echo "Synchronizing dotfiles..."
 "$REPO_DIR/sync.sh" --install "$@"

--- a/sync.sh
+++ b/sync.sh
@@ -27,6 +27,7 @@ DEST="${HOME}/.local/share/dotfiles"
 load_env() {
   ALIASES_FILE="$DEST/aliases/git.sh"
   HELPERS_FILE="$DEST/helpers.sh"
+  echo "Loading environment..."
   if [ -f "$ALIASES_FILE" ]; then
     # shellcheck disable=SC1090
     source "$ALIASES_FILE"
@@ -38,6 +39,7 @@ load_env() {
 }
 
 sync_repo() {
+  echo "Syncing repository to $DEST"
   mkdir -p "$DEST"
   rsync -av --delete \
     --exclude '.git/' \
@@ -46,7 +48,9 @@ sync_repo() {
     --exclude '.idea/' \
     "$REPO_DIR"/ "$DEST"/
   load_env
+  echo "Configuring shell profiles..."
   configure_profiles
+  echo "Sync complete."
 }
 
 configure_profiles() {
@@ -66,8 +70,10 @@ configure_profiles() {
 }
 
 install_repo() {
+  echo "Installing repository"
   git -C "$REPO_DIR" config core.hooksPath hooks
   sync_repo
+  echo "Installation complete."
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary
- show progress when installing packages and syncing dotfiles
- detail repository syncing and profile configuration steps
- log missing packages and package manager used for installation

## Testing
- `shellcheck install.sh sync.sh install-packages.sh`
- `bash -n install.sh sync.sh install-packages.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b69699810483239b96b52df6883629