### PR TITLE
feat: professionalize script output

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -1,6 +1,37 @@
 #!/usr/bin/env bash
 # General shell helper functions
 
+# ----- Styled output -------------------------------------------------------
+# These functions provide colorized, symbol-prefixed messages to make script
+# output clearer and more professional. They default to standard stdout/stderr
+# but respect INFO_FD and ERROR_FD when set by the caller.
+COLOR_RESET=$'\033[0m'
+COLOR_INFO=$'\033[1;34m'
+COLOR_SUCCESS=$'\033[1;32m'
+COLOR_WARN=$'\033[1;33m'
+COLOR_ERROR=$'\033[1;31m'
+
+info() {
+  local fd=${INFO_FD:-1}
+  printf "%sℹ %s%s\n" "$COLOR_INFO" "$*" "$COLOR_RESET" >&"$fd"
+}
+
+success() {
+  local fd=${INFO_FD:-1}
+  printf "%s✔ %s%s\n" "$COLOR_SUCCESS" "$*" "$COLOR_RESET" >&"$fd"
+}
+
+warn() {
+  local fd=${INFO_FD:-1}
+  printf "%s⚠ %s%s\n" "$COLOR_WARN" "$*" "$COLOR_RESET" >&"$fd"
+}
+
+error() {
+  local fd=${ERROR_FD:-2}
+  printf "%s✖ %s%s\n" "$COLOR_ERROR" "$*" "$COLOR_RESET" >&"$fd"
+}
+
+# ----- Progress Bar --------------------------------------------------------
 # Display a simple progress bar.
 # Usage: load_bar CURRENT TOTAL [WIDTH]
 # WIDTH defaults to 50 when not provided.

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=helpers.sh
+source "$REPO_DIR/helpers.sh"
 
 # Silence all non-echo output
 exec 3>&1 4>&2
 exec 1>/dev/null
 exec 2>/dev/null
+INFO_FD=3
+ERROR_FD=4
 
 REQUIRED_CMDS=(nvim)
 # Map commands to package names when they differ
 declare -A PKG_MAP=([nvim]=neovim)
 
-echo "Checking required commands: ${REQUIRED_CMDS[*]}" >&3
+info "Checking required commands: ${REQUIRED_CMDS[*]}"
 missing=()
 for cmd in "${REQUIRED_CMDS[@]}"; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -20,31 +26,31 @@ for cmd in "${REQUIRED_CMDS[@]}"; do
 done
 
 if [ ${#missing[@]} -eq 0 ]; then
-  echo "All required packages are installed." >&3
+  success "All required packages are installed."
   exit 0
 fi
 
-echo "Missing packages: ${missing[*]}" >&3
+warn "Missing packages: ${missing[*]}"
 SUDO=""
 if command -v sudo >/dev/null 2>&1; then
   SUDO="sudo"
 fi
 
 if command -v apt >/dev/null 2>&1; then
-  echo "Installing with apt-get: ${missing[*]}" >&3
+  info "Installing with apt-get: ${missing[*]}"
   $SUDO apt-get update
   $SUDO apt-get install -y "${missing[@]}"
 elif command -v brew >/dev/null 2>&1; then
-  echo "Installing with brew: ${missing[*]}" >&3
+  info "Installing with brew: ${missing[*]}"
   $SUDO brew install "${missing[@]}"
 elif command -v dnf >/dev/null 2>&1; then
-  echo "Installing with dnf: ${missing[*]}" >&3
+  info "Installing with dnf: ${missing[*]}"
   $SUDO dnf install -y "${missing[@]}"
 elif command -v pacman >/dev/null 2>&1; then
-  echo "Installing with pacman: ${missing[*]}" >&3
+  info "Installing with pacman: ${missing[*]}"
   $SUDO pacman -Syu --noconfirm "${missing[@]}"
 else
-  echo "No supported package manager found. Please install: ${missing[*]}" >&4
+  error "No supported package manager found. Please install: ${missing[*]}"
   exit 1
 fi
-echo "Package installation complete." >&3
+success "Package installation complete."

--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,17 @@
 set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=helpers.sh
+source "$REPO_DIR/helpers.sh"
+
 # Silence all non-echo output
 exec 3>&1 4>&2
 exec 1>/dev/null
 exec 2>/dev/null
+INFO_FD=3
+ERROR_FD=4
 
-echo "Installing required packages..." >&3
+info "Installing required packages..."
 "$REPO_DIR/install-packages.sh" 1>&3 2>&4
-echo "Synchronizing dotfiles..." >&3
+info "Synchronizing dotfiles..."
 "$REPO_DIR/sync.sh" --install "$@" 1>&3 2>&4

--- a/sync.sh
+++ b/sync.sh
@@ -18,6 +18,8 @@ fi
 exec 3>&1 4>&2
 exec 1>/dev/null
 exec 2>/dev/null
+INFO_FD=3
+ERROR_FD=4
 
 # Determine the directory containing this script for Bash and Zsh
 if [ -n "${BASH_SOURCE[0]:-}" ]; then
@@ -27,12 +29,15 @@ else
   SCRIPT_PATH="${(%):-%x}"
 fi
 REPO_DIR="$(cd "$(dirname "$SCRIPT_PATH")" && pwd)"
+
+# shellcheck source=helpers.sh
+source "$REPO_DIR/helpers.sh"
 DEST="${HOME}/.local/share/dotfiles"
 
 load_env() {
   ALIASES_FILE="$DEST/aliases/git.sh"
   HELPERS_FILE="$DEST/helpers.sh"
-  echo "Loading environment..." >&3
+  info "Loading environment..."
   if [ -f "$ALIASES_FILE" ]; then
     # shellcheck disable=SC1090
     source "$ALIASES_FILE"
@@ -44,7 +49,7 @@ load_env() {
 }
 
 sync_repo() {
-  echo "Syncing repository to $DEST" >&3
+  info "Syncing repository to $DEST"
   mkdir -p "$DEST"
   rsync -av --delete \
     --exclude '.git/' \
@@ -53,9 +58,9 @@ sync_repo() {
     --exclude '.idea/' \
     "$REPO_DIR"/ "$DEST"/
   load_env
-  echo "Configuring shell profiles..." >&3
+  info "Configuring shell profiles..."
   configure_profiles
-  echo "Sync complete." >&3
+  success "Sync complete."
 }
 
 configure_profiles() {
@@ -75,10 +80,10 @@ configure_profiles() {
 }
 
 install_repo() {
-  echo "Installing repository" >&3
+  info "Installing repository"
   git -C "$REPO_DIR" config core.hooksPath hooks
   sync_repo
-  echo "Installation complete." >&3
+  success "Installation complete."
 }
 
 case "${1:-}" in


### PR DESCRIPTION
## Summary
- add colorized log helpers for consistent, professional messages
- use styled helpers across install, package, and sync scripts

## Testing
- `shellcheck install.sh install-packages.sh sync.sh helpers.sh`
- `bash -n install.sh install-packages.sh sync.sh helpers.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b69d14e0fc8323a6aba182599d1bea