### PR TITLE
Use batcat via cat alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Run `./install.sh` (which also installs missing dependencies) or `./sync.sh --in
 ## Aliases
 - `git-prune-branches`: fetch all remote branches, check out `main`, and delete all other local and remote branches.
 - `aliases`: list all defined aliases with descriptions in a simplified colorized list.
+- `cat`: display files with syntax highlighting via `batcat`.
 
 ## Utilities
 - `load_bar`: render a basic progress bar for shell scripts.

--- a/aliases/cat.sh
+++ b/aliases/cat.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# shell aliases for cat replacement
+
+# shellcheck source=../helpers.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../helpers.sh"
+
+alias_cat_desc='Display files with syntax highlighting via batcat'
+alias cat='batcat'
+

--- a/aliases/git.sh
+++ b/aliases/git.sh
@@ -48,6 +48,9 @@ _aliases() {
       git-squash-first)
         desc=$alias_git_squash_first_desc
         ;;
+      cat)
+        desc=$alias_cat_desc
+        ;;
       *)
         desc=''
         ;;

--- a/install-packages.sh
+++ b/install-packages.sh
@@ -12,9 +12,9 @@ exec 2>/dev/null
 INFO_FD=3
 ERROR_FD=4
 
-REQUIRED_CMDS=(nvim)
+REQUIRED_CMDS=(nvim batcat)
 # Map commands to package names when they differ
-declare -A PKG_MAP=([nvim]=neovim)
+declare -A PKG_MAP=([nvim]=neovim [batcat]=bat)
 
 info "Checking required commands: ${REQUIRED_CMDS[*]}"
 missing=()

--- a/sync.sh
+++ b/sync.sh
@@ -35,14 +35,16 @@ source "$REPO_DIR/helpers.sh"
 DEST="${HOME}/.local/share/dotfiles"
 
 load_env() {
-  ALIASES_FILE="$DEST/aliases/git.sh"
+  ALIASES_DIR="$DEST/aliases"
   HELPERS_FILE="$DEST/helpers.sh"
   info "Loading environment..."
-  if [ -f "$ALIASES_FILE" ]; then
-    # shellcheck disable=SC1090
-    source "$ALIASES_FILE"
+  if [ -d "$ALIASES_DIR"  ]; then
+    for file in "$ALIASES_DIR"/*.sh; do
+      # shellcheck disable=SC1090
+      [ -f "$file" ] && source "$file"
+    done
   fi
-  if [ -f "$HELPERS_FILE" ]; then
+  if [ -f "$HELPERS_FILE"  ]; then
     # shellcheck disable=SC1090
     source "$HELPERS_FILE"
   fi
@@ -65,7 +67,7 @@ sync_repo() {
 
 configure_profiles() {
   PROFILES=("$HOME/.bashrc" "$HOME/.zshrc")
-  ALIASES_SNIPPET='[ -f "$HOME/.local/share/dotfiles/aliases/git.sh" ] && source "$HOME/.local/share/dotfiles/aliases/git.sh"'
+  ALIASES_SNIPPET='for f in "$HOME/.local/share/dotfiles/aliases/"*.sh; do [ -f "$f" ] && source "$f"; done'
   HELPERS_SNIPPET='[ -f "$HOME/.local/share/dotfiles/helpers.sh" ] && source "$HOME/.local/share/dotfiles/helpers.sh"'
 
   for PROFILE in "${PROFILES[@]}"; do


### PR DESCRIPTION
## Summary
- Install `bat` when `batcat` command is missing
- Load all alias scripts and add `cat` alias to `batcat`
- Document new syntax-highlighted `cat` alias

## Testing
- `bash -n install-packages.sh`
- `bash -n sync.sh`
- `bash -n aliases/cat.sh`
- `bash -n aliases/git.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b6a1f4caf48323a978c57ac7bc25f9